### PR TITLE
Mobile styling of infobar, form and sidebar

### DIFF
--- a/client/MainBox.jsx
+++ b/client/MainBox.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import TrackerReact from 'meteor/ultimatejs:tracker-react';
 import SubHeader from './layouts/SubHeader.jsx';
 import InfoBar from './InfoBar.jsx';
+import InfoBarMobile from './layouts/InfoBarMobile.jsx';
 
 
 export default class MainBox extends TrackerReact(React.Component) {
@@ -26,6 +27,9 @@ export default class MainBox extends TrackerReact(React.Component) {
 
 	        <InfoBar
 	          show={this.props.showinfobar}
+	          content={this.props.infobar}
+	          />
+					<InfoBarMobile
 	          content={this.props.infobar}
 	          />
 	      </div>

--- a/client/event/EventCalendar.jsx
+++ b/client/event/EventCalendar.jsx
@@ -61,10 +61,17 @@ export default class EventCalendar extends TrackerReact(React.Component) {
   componentDidMount(){
     var thiz = this;
     console.log(Session.get("calendardate"));
+    var mq = window.matchMedia( "only screen and (max-width: 992px)" );
+    var calView = "listWeek";
+    if (mq.matches) {
+      calView = "listWeek";
+    } else {
+      calView = Meteor.user().preferences.calendar_view;
+    }
     $("#calendar").fullCalendar({
       events: [],
       header: false,
-      defaultView: Meteor.user().preferences.calendar_view,
+      defaultView: calView,
       firstDay: 1,
       fixedWeekCount: false,
       theme: false,
@@ -88,7 +95,15 @@ export default class EventCalendar extends TrackerReact(React.Component) {
         //   return;
         // }
         //Session.set("infobar",true);
-        Meteor.call("openEventInfoBar");
+
+        var mq = window.matchMedia( "only screen and (max-width: 992px)" );
+
+        if (mq.matches) {
+          $('#fake-button').sideNav('show');
+        } else {
+          Meteor.call("openEventInfoBar");
+        }
+
         Session.set("evselected",calEvent._id);
         //$('.modal').modal();
         //console.log(calEvent._id);

--- a/client/event/EventCalendarWrapper.jsx
+++ b/client/event/EventCalendarWrapper.jsx
@@ -75,22 +75,22 @@ export default class EventCalendarWrapper extends TrackerReact(React.Component) 
       <h1>{this.state.viewtitle}</h1>
       <li onClick={this.nextCal.bind(this)}><a><i className="material-icons black-text">skip_next</i></a></li>
       </ul>
-      <ul className="right">
+      <ul className="right hide-on-small-only">
         <li><a href="/events/debrief" className="tooltipped" data-position="bottom" data-delay="50" data-tooltip="Event Debriefs"><i className="material-icons black-text">subject</i></a></li>
       <li><a id="eventdropdownbutton" className="dropdown-button tooltipped" data-activates="caldrop" data-position="bottom" data-delay="50" data-tooltip="Views">
       {view=="month" ? <i className="material-icons black-text">today</i> :
         view=="agendaWeek" ? <i className="material-icons black-text">view_week</i> :
         view=="listWeek" ? <i className="material-icons black-text">view_list</i> : 'test' }
       </a></li>
-      <li><a>|</a></li>
-      <li onClick={this.toggleInfoBar.bind(this)}><a className="tooltipped" data-position="bottom" data-delay="50" data-tooltip="Show/Hide Infobar">
+    <li className="hide-on-small-only"><a>|</a></li>
+      <li onClick={this.toggleInfoBar.bind(this)}><a className="tooltipped hide-on-med-and-down" data-position="bottom" data-delay="50" data-tooltip="Show/Hide Infobar">
         <i className="material-icons black-text">
           {Meteor.user().preferences.events_infobar?"info":"info_outline"}
         </i>
       </a></li>
-    <li><a onClick={this.openHelp.bind(this)} className="tooltipped" data-position="bottom" data-delay="50" data-tooltip="Help"><i className="material-icons black-text">live_help</i></a></li>
+    <li><a onClick={this.openHelp.bind(this)} className="tooltipped hide-on-small-only" data-position="bottom" data-delay="50" data-tooltip="Help"><i className="material-icons black-text">live_help</i></a></li>
       </ul>
-    <ul id="caldrop" className="dropdown-content">
+    <ul id="caldrop" className="dropdown-content hide-on-small-only">
       <li onClick={this.monthView.bind(this)}><a><i className={view=="month" ? "material-icons gold-text" : "material-icons black-text"}>today</i></a></li>
       <li onClick={this.weekView.bind(this)}><a><i className={view=="agendaWeek" ? "material-icons gold-text" : "material-icons black-text"}>view_week</i></a></li>
       <li onClick={this.listView.bind(this)}><a><i className={view=="listWeek" ? "material-icons gold-text" : "material-icons black-text"}>view_list</i></a></li>

--- a/client/layouts/Footer.jsx
+++ b/client/layouts/Footer.jsx
@@ -28,7 +28,7 @@ export default class Footer extends TrackerReact(React.Component) {
 			<footer className="page-footer">
 				<div className="footer-copyright">
 	        <div className="container">
-	        &nbsp;{"Ivy v1.0.4"}{/*find way of doing version number with settings or something here*/}
+	        &nbsp;{"Ivy v1.0.7"}{/*find way of doing version number with settings or something here*/}
 	        <a className="grey-text text-lighten-4 right" target="_blank" href="http://ivcf.rit.edu">ivcf.rit.edu</a>
 	        </div>
 	      </div>

--- a/client/layouts/InfoBarMobile.jsx
+++ b/client/layouts/InfoBarMobile.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import TrackerReact from 'meteor/ultimatejs:tracker-react';
+
+
+export default class InfoBarMobile extends TrackerReact(React.Component) {
+	constructor(){
+		super();
+		// if(!Session.get("infobar")){
+		// 	Session.set("infobar",true);
+		// }
+	}
+
+  componentDidMount() {
+    $('#fake-button').sideNav({
+      menuWidth: 240, // Default is 300
+      edge: 'right', // Choose the horizontal origin
+      closeOnClick: true // Closes side-nav on <a> clicks, useful for Angular/Meteor
+    });
+    $('#info-bar-mobile').appendTo('body');
+  }
+
+  componentWillUnmount(){
+    $('#fake-button').sideNav("destroy");
+  }
+
+	stopit(event){
+		event.stopPropagation();
+	}
+
+	render() {
+		return (
+      <div>
+        <a id="fake-button" data-activates="info-bar-mobile">.</a>
+  			<ul id="info-bar-mobile" className="side-nav right">
+  				{this.props.content}
+  			</ul>
+      </div>
+		)
+	}
+}

--- a/client/layouts/SideBar.jsx
+++ b/client/layouts/SideBar.jsx
@@ -172,7 +172,7 @@ export default class SideBar extends TrackerReact(React.Component) {
 				</ul>
 			</li>
 				}
-				<li className="">
+				<li id="toggleCollapse">
 					<a className="waves-effect collapsible-header" onClick={this.toggleCollapse.bind(this)}>
 						<span className="nav-icon">
 							<i id="nav-collapse-button" className="material-icons">play_circle_filled</i>

--- a/client/styles/Events/SignInForm.scss
+++ b/client/styles/Events/SignInForm.scss
@@ -40,6 +40,11 @@
   background-position: bottom left, bottom right;
   background-repeat: no-repeat, no-repeat;
   background-size: 30rem, 30rem;
+  @media only screen and (max-width: 992px) {
+    height: 100vh;
+    padding: 0;
+    margin: 0;
+  }
 }
 
 #form-back:before {
@@ -69,6 +74,12 @@
   width: 100%;
   max-width: 500px;
   overflow: hidden;
+  @media only screen and (max-width: 992px) {
+    overflow-y: auto;
+    height: 100vh;
+    margin: 0;
+    padding: 10px;
+  }
 }
 
 .publicForm {
@@ -144,7 +155,11 @@
     //z-index: 2 !important;
     font-size: 1.5em !important;
   }
-
+  @media only screen and (max-width: 992px) {
+    height: 100vh;
+    margin: 0;
+    padding: 0;
+  }
 }
 
 .react-autosuggest__container {

--- a/client/styles/Layout/InfoBox.scss
+++ b/client/styles/Layout/InfoBox.scss
@@ -10,6 +10,10 @@
   overflow-y: auto;
   -webkit-transition: right 0.3s;
   transition: right 0.3s;
+
+  @media only screen and (max-width: 992px) {
+    display: none;
+  }
 }
 
 .infohide {

--- a/client/styles/Layout/MainBox.scss
+++ b/client/styles/Layout/MainBox.scss
@@ -9,6 +9,10 @@
   right: 300px;
   -webkit-transition: right 0.3s;
   transition: right 0.3s;
+
+  @media only screen and (max-width: 992px) {
+  right: 0;
+  }
 }
 
 .main-box > div {

--- a/client/styles/Layout/SideBar.scss
+++ b/client/styles/Layout/SideBar.scss
@@ -54,7 +54,7 @@ ul#side-nav {
 }
 
 ul.custom-collapsible {
-  background-color: #eee;
+  background-color: rgba(0, 0, 0, 0.05);
   > li > a {
     padding: 0 10px !important;
   }
@@ -68,4 +68,9 @@ ul.custom-collapsible {
 
 #nav-collapse-button.nav-collapsed {
   transform: rotate(0);
+}
+
+#toggleCollapse > a {
+  font-style: italic;
+  font-size: 0.8em;
 }

--- a/client/styles/sass/components/_collapsible.scss
+++ b/client/styles/sass/components/_collapsible.scss
@@ -57,6 +57,7 @@
 
     &:hover { background-color: rgba(0,0,0,.05); }
     i { line-height: inherit; }
+    .active { background-color: rgba(0, 0, 0, 0.05); }
   }
 
   .collapsible-body {

--- a/client/styles/sass/components/_sideNav.scss
+++ b/client/styles/sass/components/_sideNav.scss
@@ -26,9 +26,9 @@
     right: 0;
     height: 100%;
     background-color: #fcfcfc;
-    margin-top: 63px;
+    //margin-top: 63px;
     width: 400px;
-    z-index: 0;
+    z-index: 998;
     position: fixed;
     transform: translateX(105%);
     left: auto;
@@ -213,13 +213,27 @@
 }
 
 
+.side-nav li.active > a {
+  > .nav-icon {
+    color: #1a3d6d;
+  }
+  > .nav-label {
+    color: #1a3d6d;
+  }
+}
+
 .side-nav .collapsible-body > ul:not(.collapsible) > li.active,
 .side-nav.fixed .collapsible-body > ul:not(.collapsible) > li.active {
+  > a > i.material-icons {
   //background-color: $primary-color;
-  background-color: #FCB816;
-  a {
-    color: $sidenav-bg-color;
+    color: #1a3d6d;
   }
+  > a > .nav-label {
+    color: #1a3d6d;
+  }
+  /*a {
+    color: $sidenav-bg-color;
+  }*/
 }
 
 


### PR DESCRIPTION
- Sidebar changed collapse button styling
- Tagged active page on sidebar navbar.
- Fixed mobile InfoBar
- Hid the extra subheader buttons on events calendar
- Made list view event calendar default for mobile
- Fixed mobile sign in form