### PR TITLE
Made Email Center's newsletter tailored functions more generic.

### DIFF
--- a/client/email/summary/EmailRow.jsx
+++ b/client/email/summary/EmailRow.jsx
@@ -83,9 +83,9 @@ export default class EmailSummary extends TrackerReact(React.Component){
 			<li className={"collection-item trunc-cell"+this.isSelected()}
 				onClick={this.handleClick.bind(this)}
 				onDoubleClick={this.handleDoubleClick.bind(this)} >
-				<span style={{width: "20%", display: "inline-block"}}>{email.subject}</span>
+				<span style={{width: "20%", display: "inline-block"}} title={email.subject}>{email.subject}</span>
 				<span style={{width: "30%", display: "inline-block"}}>{this.getTo()}</span>
-				<span style={{width: "15%", display: "inline-block"}}>{email.from}</span>
+				<span style={{width: "15%", display: "inline-block"}} title={email.from}>{email.from}</span>
 				<span style={{width: "15%", display: "inline-block"}}>{this.getTemplate()}</span>
 				<span style={{width: "20%", display: "inline-block"}}>{dateFormat(email.when)}</span>
 			</li>

--- a/client/email/summary/NewEmail.jsx
+++ b/client/email/summary/NewEmail.jsx
@@ -48,7 +48,7 @@ export default class NewEmail extends React.Component {
             })}
           </select>
         </NavbarItem>
-        <NavbarItem onClick={this.handleSubmit}>
+        <NavbarItem onClick={this.handleSubmit} tooltip={{text: "Create new email based on selected template"}}>
           <MaterialIcon className="black-text" icon="add" />
         </NavbarItem>
       </form>
@@ -86,7 +86,7 @@ export default class NewEmail extends React.Component {
 const tos = {
   newsletter: {
     users: [],
-    groups: [],
+    groups: ["newsletter"],
     emails: []
   },
   prayergroup: {

--- a/client/jobs/JobManagerFilter.jsx
+++ b/client/jobs/JobManagerFilter.jsx
@@ -30,7 +30,7 @@ export default class JobManagerFilter extends React.Component {
 									<select onChange={this.handleFilterChange.bind(this)} value={this.props.activeFilter} className="browser-default">
 										<option value="">Select a Job Type</option>
 										<option value="sendEmail">Send Email</option>
-										<option value="sendNewsletter">Send Newsletter</option>
+										<option value="email">Email Center Email</option>
 										<option value="sendEventFollowUpEmail">Send Event Follow Up</option>
 										<option value="checkFunnelStatus">Check Funnel Status</option>
 										<option value="processExpiredContacts">Process Expired Contacts</option>

--- a/lib/classes/Contact.js
+++ b/lib/classes/Contact.js
@@ -67,14 +67,14 @@ export default class Contact {
 	}
 
 	isSignedUpForNewsletter(){
-		return this.newsletter;
+		return !!Groups.findOne({_id: "newsletter", users: this._id});
 	}
 
 	getNewsletter(){
-		return this.newsletter;
+		return !!Groups.findOne({_id: "newsletter", users: this._id});
 	}
 
-	setNewsletter(checked){
+	setNewsletter(checked) {
 		Meteor.call('updateNewsletter', this._id, checked);
 	}
 

--- a/lib/emails.js
+++ b/lib/emails.js
@@ -15,11 +15,11 @@ export {
 	setUserEmailRecipients,
 	addGroupEmailRecipient,
 	addEmailEmailRecipient,
-	stageNewsletter,
-	unstageNewsletter,
-	sendNewsletter,
-	changeNewsletterSendDateTime,
+	stageEmail,
+	unstageEmail,
+	changeSendDateTime,
 	createNewEventFollowUpEmail,
+	sendEmailCenterEmail,
 	sendEventFollowUpEmail,
 	sendToDoEmail,
 	buildHTML,
@@ -95,16 +95,16 @@ function setEmailStatus(emid, status){
 	Emails.update(emid, {$set: {status: status}});
 }
 
-function stageNewsletter(emid){
+function stageEmail(emid){
 	let email = Emails.findOne(emid);
 	if(email.status == "draft"){
 		setEmailStatus(emid, "staged");
-		let job = newNewsletterJob(emid);
+		let job = newEmailJob(emid);
 		scheduleJobAndSubmit(job, email.when);
 	}
 }
 
-function unstageNewsletter(emid){
+function unstageEmail(emid){
 	let email = Emails.findOne(emid);
 	if(email.status == "staged"){
 		setEmailStatus(emid, "draft");
@@ -112,7 +112,7 @@ function unstageNewsletter(emid){
 	}
 }
 
-function changeNewsletterSendDateTime(emid, newDateTime){
+function changeSendDateTime(emid, newDateTime){
 	let email = Emails.findOne(emid);
 	if(email.status != "sent"){
 		if(email.status == "staged"){
@@ -124,10 +124,10 @@ function changeNewsletterSendDateTime(emid, newDateTime){
 	}
 }
 
-function sendToMe(emid, uid=""){
+function sendToMe( emid, uid="" ) {
 	let email = Emails.findOne(emid);
 	let emailHtml = buildHTML(email, uid);
-	newEmailJob({
+	newSendEmailJob({
 		to: getUser(uid).getEmail(),
 		from: email.from,
 		subject: email.subject,
@@ -137,19 +137,9 @@ function sendToMe(emid, uid=""){
 
 }
 
-function sendNewsletter(emid){
-	let email = Emails.findOne(emid);
-
-	// Build recipient list
-	let recipients = getUsers({newsletter: true});
-	let userIdList = [];
-	recipients.map( (recipient) => {
-		userIdList.push(recipient._id);
-	});
-	setUserEmailRecipients(emid, userIdList);
-
+function sendEmailCenterEmail(emid){
 	// Send Email
-	send(email._id);
+	send(emid);
 }
 
 function createNewEventFollowUpEmail(eid, uid){
@@ -202,7 +192,7 @@ function send(emid){
 	email.to.users.map( (userId) => {
 		let user = getUser(userId);
 		let emailHtml = buildHTML(email, userId);
-		newEmailJob({
+		newSendEmailJob({
 			to: user.getEmail(),
 			from: email.from,
 			subject: email.subject,
@@ -217,7 +207,7 @@ function send(emid){
 		group.users.map( (userId)=>{
 			let user = getUser(userId);
 			let emailHtml = buildHTML(email, userId);
-			newEmailJob({
+			newSendEmailJob({
 				to: user.getEmail(),
 				from: email.from,
 				subject: email.subject,
@@ -230,7 +220,7 @@ function send(emid){
 	// Send to emails
 	email.to.emails.map( (emailAddress) =>{
 		let emailHtml = buildHTML(email);
-		newEmailJob({
+		newSendEmailJob({
 			to: emailAddress,
 			from: email.from,
 			subject: email.subject,

--- a/lib/groups.js
+++ b/lib/groups.js
@@ -2,6 +2,10 @@
 export {
 	loadGroups,
 	getDefaultEventGroups,
+	addUserToGroup,
+	removeUserFromGroup,
+	addUserToNewsletterMailingList,
+	removeUserFromNewsletterMailingList,
 	removeGroup
 }
 
@@ -18,6 +22,40 @@ function getDefaultEventGroups(){
 	return perms;
 }
 
+function addUserToGroup({ gid, uid }) {
+	const group = Groups.findOne(gid);
+
+	if (!group) {
+		throw "Invalid group ID provided";
+	}
+
+	Groups.update(gid,
+		{$addToSet: {users: uid}}
+	);
+
+	if( Meteor.isServer && group.type != "Mailing List" ) {
+		calculateFunnelStatus(uid);
+	}
+
+}
+
+function removeUserFromGroup({ gid, uid }) {
+	const group = Groups.findOne(gid);
+
+	if (!group) {
+		throw "Invalid group ID provided";
+	}
+
+	Groups.update(gid,
+		{$pull: {users: uid}}
+	);
+
+	if( Meteor.isServer && group.type != "Mailing List" ) {
+		calculateFunnelStatus(uid);
+	}
+
+}
+
 function removeGroup(id){
 	const hasEvents = (Events.find({groupId: id}).fetch().length > 0);
 	if (hasEvents) {
@@ -26,4 +64,13 @@ function removeGroup(id){
 		Groups.remove(id);
 		return true;
 	}
+
+}
+
+function addUserToNewsletterMailingList(uid) {
+	addUserToGroup({gid: "newsletter", uid: uid});
+}
+
+function removeUserFromNewsletterMailingList(uid) {
+	removeUserFromGroup({gid: "newsletter", uid: uid});
 }

--- a/lib/methods.js
+++ b/lib/methods.js
@@ -9,7 +9,13 @@ import {
  } from '/lib/events.js';
 import { addTicketNote, setTicketStatus, addTicket } from '/lib/tickets.js';
 import { getUser } from '/lib/users.js';
-import { removeGroup } from '/lib/groups.js';
+import {
+	removeGroup,
+	addUserToGroup,
+	removeUserFromGroup,
+	addUserToNewsletterMailingList,
+	removeUserFromNewsletterMailingList
+} from '/lib/groups.js';
 
 Meteor.methods({
   addGroup(nme,typ,perms,usrs,ldr){
@@ -40,20 +46,10 @@ Meteor.methods({
     });
   },
   addUserToGroup(gid, uid){
-    Groups.update(gid,
-      {$addToSet: {users: uid}}
-    );
-		if(Meteor.isServer){
-			calculateFunnelStatus(uid);
-		}
+    addUserToGroup({ gid: gid, uid: uid });
   },
   removeUserFromGroup(gid, uid){
-    Groups.update(gid,
-      {$pull: {users: uid}}
-    );
-		if(Meteor.isServer){
-			calculateFunnelStatus(uid);
-		}
+		removeUserFromGroup({ gid: gid, uid: uid });
   },
   updateGroupName(gid, text){
     Groups.update(gid, {$set:{name: text}});
@@ -485,6 +481,11 @@ Meteor.methods({
     Meteor.users.update(uid, {$set: {"bio": bi}});
   },
   updateNewsletter(uid, status){
+		if (status) {
+			addUserToNewsletterMailingList(uid);
+		} else {
+			removeUserFromNewsletterMailingList(uid);
+		}
     Meteor.users.update(uid, {$set: {"newsletter": status}});
   },
   updateMember(uid, status){

--- a/server/configs/dbinit.js
+++ b/server/configs/dbinit.js
@@ -25,6 +25,12 @@ let groups = [
 		name: "Administrator",
 		users: [],
 		type: "Permission Group"
+	},
+	{
+		_id: "newsletter",
+		name: "Newsletter Recipients",
+		users: [],
+		type: "Mailing List"
 	}
 ];
 groups.forEach( (group) => {

--- a/server/emailCenterMethods.js
+++ b/server/emailCenterMethods.js
@@ -6,9 +6,9 @@ import {
 	setUserEmailRecipients,
 	addGroupEmailRecipient,
 	addEmailEmailRecipient,
-	stageNewsletter,
-	unstageNewsletter,
-	changeNewsletterSendDateTime,
+	stageEmail,
+	unstageEmail,
+	changeSendDateTime,
 	createNewEventFollowUpEmail,
 	sendToMe
 } from '/lib/emails.js';
@@ -43,7 +43,7 @@ Meteor.methods({
     Emails.update(emid, {$set: {from: from}});
   },
   updateEmailWhen(emid, when){
-    changeNewsletterSendDateTime(emid, when);
+    changeSendDateTime(emid, when);
   },
   updateEmailStaged(emid, stg){
     Emails.update(emid, {$set: {staged: stg}});
@@ -57,15 +57,11 @@ Meteor.methods({
   },
 
   stageEmail(emid){
-    stageNewsletter(emid);
+    stageEmail(emid);
   },
 
 	unstageEmail(emid){
-		unstageNewsletter(emid);
-	},
-
-	stageNewsletter(emid){
-		stageNewsletter(emid);
+		unstageEmail(emid);
 	},
 
   newEmailTemplate(email, ttle){

--- a/server/eventmethods.js
+++ b/server/eventmethods.js
@@ -8,6 +8,7 @@ import {
 import { addTicket } from '/lib/tickets.js';
 import Contact from '/lib/classes/Contact.js';
 import { createNewUser } from '/lib/users.js';
+import { addUserToNewsletterMailingList } from '/lib/groups.js';
 
 
 Meteor.methods({
@@ -49,7 +50,7 @@ Meteor.methods({
 	      addAttendanceRecord(signin);
 
 	      if(signin.newsletter){
-	        Meteor.call("updateNewsletter", signin.uid, true);
+					addUserToNewsletterMailingList(signin.uid);
 	      }
 	      if(signin.learnmore){
 	        Meteor.call("addLearnMoreTicket", signin.uid);


### PR DESCRIPTION
- Added title attributes to the email center email rows
- Added tooltip to the new email button
- Made default recipient group for newsletter email "newsletter"
- Altered name of sendNewsletter job in JobManager to generic Email
Center
- Updated the newsletter process to be a group instead of a flag
- Updated group add/remove user functions to make them more reusable
- Added newsletter recipient groups to DB Init